### PR TITLE
fix following and follower methods on following model

### DIFF
--- a/app/models/inkwell/following.rb
+++ b/app/models/inkwell/following.rb
@@ -1,6 +1,7 @@
 module Inkwell
   class Following < ActiveRecord::Base
-    belongs_to :following, :foreign_key => :followed_id
-    belongs_to :follower, :foreign_key => :follower_id
+    user_class = ::Inkwell::Engine::config.user_table.to_s.singularize.capitalize
+    belongs_to :following, :foreign_key => :followed_id, class_name: user_class
+    belongs_to :follower, :foreign_key => :follower_id, class_name: user_class
   end
 end


### PR DESCRIPTION
This PR would make the following code work:

```
user1.follow user2
f = Inkwell::Following.first
f.follower # it's this one -> without the PR, it returns 'undefined Constant' 
f.following # and this one as well
```

Cheers, and thanks for the great work!
